### PR TITLE
feat: update invalid issue penalty from 0.5 to 2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ docker build -t bounty-challenge .
 Points are calculated as:
 - 1 point per valid issue
 - 0.25 points per starred repository (max 5 repos)
-- -0.5 penalty per invalid issue
+- -2 penalty per invalid issue
 
 Weight formula: `min(points × 0.02, 1.0)`
 

--- a/README.md
+++ b/README.md
@@ -101,13 +101,13 @@ See [Scoring Documentation](docs/reference/scoring.md) for complete specificatio
 
 | Rule | Description |
 |------|-------------|
-| **Penalty** | -0.5 points per invalid issue |
+| **Penalty** | -2 points per invalid issue |
 | **Zero Weight** | If net points < 0, weight = 0 |
 | **Recovery** | Submit valid issues to restore positive balance |
 
 **Formula:**
 ```
-net_points = valid_issues - (invalid_issues × 0.5)
+net_points = valid_issues - (invalid_issues × 2)
 weight = net_points > 0 ? (net_points × 0.02) : 0
 ```
 
@@ -115,8 +115,8 @@ weight = net_points > 0 ? (net_points × 0.02) : 0
 
 | Miner | Valid | Invalid | Net Points | Weight |
 |-------|-------|---------|------------|--------|
-| A | 10 | 2 | 9 | 18% |
-| B | 3 | 8 | -1 | 0% (penalized) |
+| A | 10 | 2 | 6 | 12% |
+| B | 3 | 8 | -13 | 0% (penalized) |
 
 ### Star Bonus
 

--- a/docs/miner/getting-started.md
+++ b/docs/miner/getting-started.md
@@ -73,7 +73,7 @@ Create quality issues (bug reports, feature requests, security issues, documenta
 
 Maintainers will review your issue:
 - ✅ Valid issue → Closed with `valid` label → **+1 point**
-- ❌ Invalid issue → Marked with `invalid` label → **-0.5 points**
+- ❌ Invalid issue → Marked with `invalid` label → **-2 points**
 - ⏳ Closed without labels → No reward or penalty
 
 ### 4. Check Your Status

--- a/docs/reference/scoring.md
+++ b/docs/reference/scoring.md
@@ -133,11 +133,11 @@ Issues marked with the `invalid` label incur penalties:
 
 | Action | Effect |
 |--------|--------|
-| **Invalid Issue** | -0.5 penalty points |
+| **Invalid Issue** | -2 penalty points |
 
 ### Balance Calculation
 
-$$balance = valid_{issues} - (invalid_{issues} \times 0.5)$$
+$$balance = valid_{issues} - (invalid_{issues} \times 2)$$
 
 If `balance < 0`, your weight becomes **0** (penalized).
 
@@ -214,13 +214,13 @@ If they get 2 more valid issues:
 ```
 Miner has 3 valid issues but 8 invalid issues:
   Valid Points: 3
-  Penalty Points: 8 × 0.5 = 4
-  Net Points: 3 - 4 = -1 (negative)
+  Penalty Points: 8 × 2 = 16
+  Net Points: 3 - 16 = -13 (negative)
   Weight: 0 (penalized)
 
-To recover, they need 3 more valid issues:
-  Net Points: 6 - 4 = 2 (positive)
-  Weight: 2 × 0.02 = 0.04 (4%)
+To recover, they need 14 more valid issues:
+  Net Points: 17 - 16 = 1 (positive)
+  Weight: 1 × 0.02 = 0.02 (2%)
 ```
 
 ---
@@ -235,7 +235,7 @@ To recover, they need 3 more valid issues:
 | `weight_per_point` | 0.02 | Weight earned per point |
 | `valid_label` | "valid" | Required label for rewards |
 | `star_bonus_per_repo` | 0.25 | Points per starred repo |
-| `invalid_penalty` | 0.5 | Points deducted per invalid |
+| `invalid_penalty` | 2 | Points deducted per invalid |
 | `min_valid_for_stars` | 2 | Min valid issues for star bonus |
 
 ### Configuration File
@@ -257,7 +257,7 @@ valid_label = "valid"
 flowchart LR
     A["Valid Issue"] --> B["+1 Point"]
     C["Star Repo"] --> D["+0.25 Points"]
-    E["Invalid Issue"] --> F["-0.5 Points"]
+    E["Invalid Issue"] --> F["-2 Points"]
     B --> G["Total Points"]
     D --> G
     F --> G

--- a/src/pg_storage.rs
+++ b/src/pg_storage.rs
@@ -586,10 +586,10 @@ impl PgStorage {
             .await?;
         let valid_points: f64 = valid_row.get::<_, f64>(0);
 
-        // Get user's invalid points (0.5 penalty per invalid issue) in last 24h
+        // Get user's invalid points (2.0 penalty per invalid issue) in last 24h
         let invalid_row = client
             .query_one(
-                "SELECT COUNT(*)::FLOAT8 * 0.5 FROM invalid_issues 
+                "SELECT COUNT(*)::FLOAT8 * 2.0 FROM invalid_issues 
                  WHERE hotkey = $1 AND recorded_at >= NOW() - INTERVAL '24 hours'",
                 &[&hotkey],
             )
@@ -793,7 +793,7 @@ impl PgStorage {
                     SELECT 
                         r.hotkey,
                         COUNT(*) as invalid_count,
-                        (COUNT(*)::FLOAT * 0.5)::INTEGER as penalty_points  -- 0.5 penalty per invalid issue
+                        (COUNT(*)::FLOAT * 2.0)::INTEGER as penalty_points  -- 2.0 penalty per invalid issue
                     FROM github_registrations r
                     JOIN invalid_issues ii ON r.hotkey = ii.hotkey
                     WHERE ii.recorded_at >= NOW() - INTERVAL '24 hours'


### PR DESCRIPTION
## Summary

Update the penalty for invalid issues from 0.5 to 2.0 across the codebase.

## Changes

- **Documentation**: Updated penalty value in AGENTS.md, README.md, getting-started.md, and scoring.md
- **SQL queries**: Updated weight calculation query in pg_storage.rs
- **Examples**: Updated all example calculations to reflect new -2 penalty

## Files Modified

- AGENTS.md - Updated coding guidelines
- README.md - Updated weight calculation documentation
- docs/miner/getting-started.md - Updated miner guide
- docs/reference/scoring.md - Updated scoring reference
- src/pg_storage.rs - Updated SQL weight calculation query

## Testing

- Code compiles successfully with cargo check
- No formatting issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Modified penalty calculation methodology for invalid issues to enhance the overall impact on weight scoring.

* **Documentation**
  * Updated comprehensive scoring system documentation with revised penalty values and calculation formulas.
  * Refreshed weighting calculation examples and configuration parameter references throughout all reference guides.
  * Updated balance calculation guidance and recovery narratives to reflect new penalty structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->