### PR TITLE
fix(weights): ensure proportional weight distribution based on points

### DIFF
--- a/migrations/012_remove_weight_cap.sql
+++ b/migrations/012_remove_weight_cap.sql
@@ -1,0 +1,79 @@
+-- Migration 012: Remove per-user weight cap
+-- Weight is now raw points * 0.02, normalized at API level
+-- This ensures users with more points always have proportionally higher weight
+
+-- ============================================================================
+-- UPDATE CURRENT WEIGHTS VIEW - REMOVE CAP
+-- ============================================================================
+DROP VIEW IF EXISTS current_weights CASCADE;
+
+CREATE OR REPLACE VIEW current_weights AS
+WITH recent_valid AS (
+    SELECT 
+        r.github_username,
+        r.hotkey,
+        COUNT(*) as valid_count  -- 1 point per issue (flat rate)
+    FROM resolved_issues r
+    WHERE r.resolved_at >= NOW() - INTERVAL '24 hours'
+      AND r.hotkey IS NOT NULL
+    GROUP BY r.github_username, r.hotkey
+),
+recent_invalid AS (
+    SELECT 
+        i.github_username,
+        i.hotkey,
+        COUNT(*) * 2 as invalid_count  -- 2 penalty per invalid issue
+    FROM invalid_issues i
+    WHERE i.recorded_at >= NOW() - INTERVAL '24 hours'
+      AND i.hotkey IS NOT NULL
+    GROUP BY i.github_username, i.hotkey
+),
+user_stars AS (
+    SELECT 
+        LOWER(github_username) as github_username,
+        COUNT(*) * 0.25 as star_points  -- 0.25 points per starred repo
+    FROM github_stars
+    GROUP BY LOWER(github_username)
+),
+user_net_points AS (
+    SELECT 
+        COALESCE(v.github_username, inv.github_username) as github_username,
+        COALESCE(v.hotkey, inv.hotkey) as hotkey,
+        COALESCE(v.valid_count, 0) as issues_resolved_24h,
+        -- Net points = valid + stars - invalid
+        COALESCE(v.valid_count, 0) + COALESCE(s.star_points, 0) - COALESCE(inv.invalid_count, 0) as net_points,
+        COALESCE(inv.invalid_count, 0) as invalid_count
+    FROM recent_valid v
+    FULL OUTER JOIN recent_invalid inv ON v.hotkey = inv.hotkey
+    LEFT JOIN user_stars s ON LOWER(COALESCE(v.github_username, inv.github_username)) = s.github_username
+    WHERE COALESCE(v.hotkey, inv.hotkey) IS NOT NULL
+),
+admin_bonus AS (
+    SELECT 
+        hotkey,
+        SUM(bonus_weight) as total_admin_bonus
+    FROM admin_bonuses
+    WHERE active = true AND expires_at > NOW()
+    GROUP BY hotkey
+)
+SELECT 
+    u.github_username,
+    u.hotkey,
+    u.issues_resolved_24h::bigint,
+    (SELECT COUNT(*) FROM resolved_issues WHERE resolved_at >= NOW() - INTERVAL '24 hours')::int as total_issues_24h,
+    -- Weight = net_points * 0.02 + admin bonus (NO CAP - normalized at API level)
+    -- If net_points <= 0, only admin bonus applies
+    CASE 
+        WHEN u.net_points <= 0 THEN COALESCE(ab.total_admin_bonus, 0)
+        ELSE u.net_points * 0.02 + COALESCE(ab.total_admin_bonus, 0)
+    END as weight,
+    u.net_points <= 0 as is_penalized
+FROM user_net_points u
+LEFT JOIN admin_bonus ab ON u.hotkey = ab.hotkey
+ORDER BY weight DESC;
+
+-- ============================================================================
+-- SCHEMA MIGRATION RECORD
+-- ============================================================================
+INSERT INTO schema_migrations (version, name) VALUES (12, 'remove_weight_cap')
+ON CONFLICT DO NOTHING;

--- a/src/server.rs
+++ b/src/server.rs
@@ -187,8 +187,9 @@ async fn get_weights_handler(
     };
 
     // Convert to WeightEntry with normalization
-    // Each user's raw weight = their points * 0.02, capped at 1.0 per user
+    // Each user's raw weight = their points * 0.02 (NO CAP - proportional to points)
     // Points: 1 per issue + 0.25 per starred repo
+    // This ensures users with more points always have proportionally higher weight
     let mut weights: Vec<WeightEntry> = current_weights
         .iter()
         .filter(|w| w.weight > 0.0 && !w.is_penalized) // Exclude zero weight and penalized users


### PR DESCRIPTION
## Problem

Users with more points were not receiving proportionally higher weights due to a 1.0 cap on per-user weight calculation. For example, users with 54 points and 50 points would both be capped at 1.0, making their weights indistinguishable after normalization.

## Solution

Remove the 1.0 cap from the weight calculation. Now weights are calculated as `raw_points * 0.02` and normalized at the API level, ensuring that users with more points always have proportionally higher weights.

## Changes

- Add migration 010: cleanup false invalid issues (remove issues incorrectly marked as invalid)
- Add migration 011: fix negative weight calculation (penalized users get 0 weight)
- Add migration 012: remove per-user weight cap (main fix)
- Update pg_storage.rs with migration runners for versions 10, 11, 12
- Update server.rs comments to clarify proportional weight distribution

## Weight Formula

- Weight = net_points * 0.02 (no cap, normalized at API level)
- Points = valid_issues + (starred_repos * 0.25) - (invalid_issues * 2)

## Testing

- Code compiles successfully with cargo check
- Migration follows existing patterns in the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Removed the weight calculation cap, allowing user weights to increase proportionally with earned points instead of being limited to a maximum threshold.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->