### PR TITLE
feat(scoring): add duplicate label detection with 0.5 point penalty

### DIFF
--- a/migrations/013_duplicate_issues.sql
+++ b/migrations/013_duplicate_issues.sql
@@ -1,0 +1,27 @@
+-- Migration 013: Duplicate Issues Tracking
+-- Track issues marked with 'duplicate' label for 0.5 point penalty (less severe than invalid's 2.0 penalty)
+
+-- ============================================================================
+-- DUPLICATE ISSUES TABLE
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS duplicate_issues (
+    id SERIAL PRIMARY KEY,
+    issue_id BIGINT NOT NULL,
+    repo_owner TEXT NOT NULL,
+    repo_name TEXT NOT NULL,
+    github_username TEXT NOT NULL,
+    hotkey TEXT,
+    issue_url TEXT NOT NULL,
+    issue_title TEXT,
+    reason TEXT DEFAULT 'Marked as duplicate',
+    recorded_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE(repo_owner, repo_name, issue_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_duplicate_username ON duplicate_issues(LOWER(github_username));
+CREATE INDEX IF NOT EXISTS idx_duplicate_hotkey ON duplicate_issues(hotkey);
+CREATE INDEX IF NOT EXISTS idx_duplicate_recorded_at ON duplicate_issues(recorded_at);
+
+-- Record this migration
+INSERT INTO schema_migrations (version) VALUES (13) ON CONFLICT DO NOTHING;

--- a/src/gh_cli.rs
+++ b/src/gh_cli.rs
@@ -51,6 +51,12 @@ impl GhIssue {
             .any(|l| l.name.to_lowercase() == "invalid")
     }
 
+    pub fn has_duplicate_label(&self) -> bool {
+        self.labels
+            .iter()
+            .any(|l| l.name.to_lowercase() == "duplicate")
+    }
+
     pub fn is_closed(&self) -> bool {
         self.state.to_lowercase() == "closed"
     }
@@ -198,6 +204,7 @@ pub async fn sync_repo_with_gh(
             Ok(change) => match change {
                 crate::pg_storage::LabelChange::BecameValid => result.became_valid += 1,
                 crate::pg_storage::LabelChange::BecameInvalid => result.became_invalid += 1,
+                crate::pg_storage::LabelChange::BecameDuplicate => result.became_duplicate += 1,
                 crate::pg_storage::LabelChange::LostValid => result.lost_valid += 1,
                 crate::pg_storage::LabelChange::None => {}
             },
@@ -239,6 +246,8 @@ pub struct SyncResult {
     pub became_valid: usize,
     /// Issues explicitly marked with "invalid" label
     pub became_invalid: usize,
+    /// Issues explicitly marked with "duplicate" label
+    pub became_duplicate: usize,
     pub lost_valid: usize,
     pub marked_deleted: usize,
     pub errors: usize,

--- a/src/github.rs
+++ b/src/github.rs
@@ -80,6 +80,12 @@ impl GitHubIssue {
             .any(|l| l.name.to_lowercase() == "invalid")
     }
 
+    pub fn has_duplicate_label(&self) -> bool {
+        self.labels
+            .iter()
+            .any(|l| l.name.to_lowercase() == "duplicate")
+    }
+
     pub fn is_closed(&self) -> bool {
         self.state == "closed"
     }


### PR DESCRIPTION
## Changes

- Add detection for issues with the `duplicate` label
- Apply a -0.5 point penalty for duplicate issues
- Create migration for duplicate issues tracking table
- Update scoring calculations to include duplicate penalties

## Files Changed

- `migrations/013_duplicate_issues.sql` - New migration for duplicate issues table
- `src/gh_cli.rs` - Add duplicate label detection
- `src/github.rs` - Add duplicate label handling
- `src/pg_storage.rs` - Update storage layer for duplicate tracking and scoring

## Testing

- Code compiles with `cargo check`
- Code is properly formatted with `cargo fmt`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced duplicate issue tracking functionality with automatic detection and recording
  * Enhanced leaderboard scoring system to incorporate duplicate issue metrics and penalties
  * Duplicate-marked issues now influence user scores through penalty adjustments

<!-- end of auto-generated comment: release notes by coderabbit.ai -->