### PR TITLE
perf(server): serve get_weights from cache only, increase GitHub sync to 10min

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use bounty_challenge::{BountyChallenge, GitHubClient, PgStorage};
 use tracing::{error, info, warn};
 use tracing_subscriber::EnvFilter;
 
-const SYNC_INTERVAL_SECS: u64 = 300; // 5 minutes
+const SYNC_INTERVAL_SECS: u64 = 600; // 10 minutes
 const STAR_SYNC_INTERVAL_SECS: u64 = 300; // 5 minutes
 const HEARTBEAT_INTERVAL_SECS: u64 = 60; // 1 minute - check GitHub API health
 
@@ -43,7 +43,7 @@ async fn main() -> anyhow::Result<()> {
         .and_then(|p| p.parse().ok())
         .unwrap_or(8080);
 
-    // Start background GitHub sync task (every 5 minutes)
+    // Start background GitHub sync task (every 10 minutes)
     let sync_storage = storage.clone();
     tokio::spawn(async move {
         // Initial sync after 10 seconds


### PR DESCRIPTION
## Summary

Make the `get_weights` endpoint fully non-blocking by reading exclusively from the in-memory weights cache, and increase the GitHub issues sync interval from 5 to 10 minutes.

## Changes

### `src/main.rs`
- Change `SYNC_INTERVAL_SECS` from 300 to 600 (10 minutes) for GitHub issue syncing
- Update the associated comment to reflect the new interval

### `src/server.rs`
- Remove the direct database query with 2-second timeout from `get_weights_handler`; the handler now reads solely from `weights_cache` (populated every 5 minutes by the existing background task)
- Remove unused `timeout` import (`tokio::time::timeout`)
- Remove unused `warn` import from `tracing`

## Rationale

Previously, every call to `get_weights` would attempt a live PostgreSQL query (with a 2s timeout fallback to cache), adding latency and unnecessary DB load. The background `refresh_weights_cache` task already keeps the cache warm every 5 minutes, so the handler can return cached data immediately with no blocking.

## Notes
- The weights cache refresh interval remains at 300s (5 minutes)
- The star sync interval remains at 300s (5 minutes)
- Filtering, normalization, and sorting logic in the handler is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added GitHub OAuth integration capabilities
  * Introduced standalone health-check server
  * Expanded CLI commands and configurations

* **Improvements**
  * Adjusted GitHub background sync interval from 5 to 10 minutes
  * Optimized weights service to use in-memory caching

<!-- end of auto-generated comment: release notes by coderabbit.ai -->